### PR TITLE
Feature: add mix size selector component

### DIFF
--- a/src/BaseRatioSelector.re
+++ b/src/BaseRatioSelector.re
@@ -1,21 +1,21 @@
 [@react.component]
-let make = (~preference: Constants.baseRatioPreference, ~handleSetBaseRatio) => {
+let make = (~preset: Constants.baseRatioPreset, ~handleSetBaseRatio) => {
   <div>
     <span> {ReasonReact.string("VG:")} </span>
     <input
       label="VG"
       type_="number"
       step=1.0
-      value={Js.Int.toString(preference.vg)}
+      value={Js.Int.toString(preset.vg)}
       onChange={event => {
         let value: int =
           ReactEvent.Form.target(event)##value >= 0
             ? ReactEvent.Form.target(event)##value : 0;
-        let newPreference: Constants.baseRatioPreference = {
+        let newBaseRatio: Constants.baseRatioPreset = {
           vg: value > 100 ? 100 : value,
           pg: value > 100 ? 0 : 100 - value,
         };
-        handleSetBaseRatio(_ => newPreference);
+        handleSetBaseRatio(_ => newBaseRatio);
       }}
     />
     <span> {ReasonReact.string("PG:")} </span>
@@ -23,16 +23,16 @@ let make = (~preference: Constants.baseRatioPreference, ~handleSetBaseRatio) => 
       label="PG"
       type_="number"
       step=1.0
-      value={Js.Int.toString(preference.pg)}
+      value={Js.Int.toString(preset.pg)}
       onChange={event => {
         let value: int =
           ReactEvent.Form.target(event)##value >= 0
             ? ReactEvent.Form.target(event)##value : 0;
-        let newPreference: Constants.baseRatioPreference = {
+        let newBaseRatio: Constants.baseRatioPreset = {
           vg: value > 100 ? 0 : 100 - value,
           pg: value > 100 ? 100 : value,
         };
-        handleSetBaseRatio(_ => newPreference);
+        handleSetBaseRatio(_ => newBaseRatio);
       }}
     />
   </div>;

--- a/src/BaseRatioSelector.re
+++ b/src/BaseRatioSelector.re
@@ -8,7 +8,6 @@ let make = (~preference: Constants.baseRatioPreference, ~handleSetBaseRatio) => 
       step=1.0
       value={Js.Int.toString(preference.vg)}
       onChange={event => {
-        Js.log(ReactEvent.Form.target(event)##value);
         let value: int =
           ReactEvent.Form.target(event)##value >= 0
             ? ReactEvent.Form.target(event)##value : 0;
@@ -26,7 +25,6 @@ let make = (~preference: Constants.baseRatioPreference, ~handleSetBaseRatio) => 
       step=1.0
       value={Js.Int.toString(preference.pg)}
       onChange={event => {
-        Js.log(ReactEvent.Form.target(event)##value);
         let value: int =
           ReactEvent.Form.target(event)##value >= 0
             ? ReactEvent.Form.target(event)##value : 0;

--- a/src/BaseRatioSelector.re
+++ b/src/BaseRatioSelector.re
@@ -9,8 +9,12 @@ let make = (~preset: Constants.baseRatioPreset, ~handleSetBaseRatio) => {
       value={Js.Int.toString(preset.vg)}
       onChange={event => {
         let value: int =
-          ReactEvent.Form.target(event)##value >= 0
-            ? ReactEvent.Form.target(event)##value : 0;
+          int_of_float(
+            Js.Math.trunc(
+              ReactEvent.Form.target(event)##value >= 0
+                ? ReactEvent.Form.target(event)##value : 0.0,
+            ),
+          );
         let newBaseRatio: Constants.baseRatioPreset = {
           vg: value > 100 ? 100 : value,
           pg: value > 100 ? 0 : 100 - value,
@@ -26,8 +30,12 @@ let make = (~preset: Constants.baseRatioPreset, ~handleSetBaseRatio) => {
       value={Js.Int.toString(preset.pg)}
       onChange={event => {
         let value: int =
-          ReactEvent.Form.target(event)##value >= 0
-            ? ReactEvent.Form.target(event)##value : 0;
+          int_of_float(
+            Js.Math.trunc(
+              ReactEvent.Form.target(event)##value >= 0
+                ? ReactEvent.Form.target(event)##value : 0.0,
+            ),
+          );
         let newBaseRatio: Constants.baseRatioPreset = {
           vg: value > 100 ? 0 : 100 - value,
           pg: value > 100 ? 100 : value,

--- a/src/BaseRatioSelector.re
+++ b/src/BaseRatioSelector.re
@@ -1,0 +1,41 @@
+[@react.component]
+let make = (~preference: Constants.baseRatioPreference, ~handleSetBaseRatio) => {
+  <div>
+    <span> {ReasonReact.string("VG:")} </span>
+    <input
+      label="VG"
+      type_="number"
+      step=1.0
+      value={Js.Int.toString(preference.vg)}
+      onChange={event => {
+        Js.log(ReactEvent.Form.target(event)##value);
+        let value: int =
+          ReactEvent.Form.target(event)##value >= 0
+            ? ReactEvent.Form.target(event)##value : 0;
+        let newPreference: Constants.baseRatioPreference = {
+          vg: value > 100 ? 100 : value,
+          pg: value > 100 ? 0 : 100 - value,
+        };
+        handleSetBaseRatio(_ => newPreference);
+      }}
+    />
+    <span> {ReasonReact.string("PG:")} </span>
+    <input
+      label="PG"
+      type_="number"
+      step=1.0
+      value={Js.Int.toString(preference.pg)}
+      onChange={event => {
+        Js.log(ReactEvent.Form.target(event)##value);
+        let value: int =
+          ReactEvent.Form.target(event)##value >= 0
+            ? ReactEvent.Form.target(event)##value : 0;
+        let newPreference: Constants.baseRatioPreference = {
+          vg: value > 100 ? 0 : 100 - value,
+          pg: value > 100 ? 100 : value,
+        };
+        handleSetBaseRatio(_ => newPreference);
+      }}
+    />
+  </div>;
+};

--- a/src/Calculator.re
+++ b/src/Calculator.re
@@ -2,14 +2,14 @@
 let make = () => {
   let (nicWeight, setNicWeight) = React.useState(() => 50.0);
 
-  let preference: Constants.preference = {
+  let preset: Constants.preset = {
     baseRatio: {
       vg: 70,
       pg: 30,
     },
   };
 
-  let (baseRatio, setBaseRatio) = React.useState(() => preference.baseRatio);
+  let (baseRatio, setBaseRatio) = React.useState(() => preset.baseRatio);
 
   <div>
     <div>
@@ -17,10 +17,7 @@ let make = () => {
       <p> {ReasonReact.string(Js.Float.toString(nicWeight))} </p>
     </div>
     <div>
-      <BaseRatioSelector
-        preference=baseRatio
-        handleSetBaseRatio=setBaseRatio
-      />
+      <BaseRatioSelector preset=baseRatio handleSetBaseRatio=setBaseRatio />
     </div>
   </div>;
 };

--- a/src/Calculator.re
+++ b/src/Calculator.re
@@ -2,8 +2,25 @@
 let make = () => {
   let (nicWeight, setNicWeight) = React.useState(() => 50.0);
 
+  let preference: Constants.preference = {
+    baseRatio: {
+      vg: 70,
+      pg: 30,
+    },
+  };
+
+  let (baseRatio, setBaseRatio) = React.useState(() => preference.baseRatio);
+
   <div>
-    <NicBaseSelector handleSetNicWeight=setNicWeight />
-    <p> {ReasonReact.string(Js.Float.toString(nicWeight))} </p>
+    <div>
+      <NicBaseSelector handleSetNicWeight=setNicWeight />
+      <p> {ReasonReact.string(Js.Float.toString(nicWeight))} </p>
+    </div>
+    <div>
+      <BaseRatioSelector
+        preference=baseRatio
+        handleSetBaseRatio=setBaseRatio
+      />
+    </div>
   </div>;
 };

--- a/src/Calculator.re
+++ b/src/Calculator.re
@@ -3,6 +3,7 @@ let make = () => {
   let (nicWeight, setNicWeight) = React.useState(() => 50.0);
 
   let preset: Constants.preset = {
+    name: "default",
     baseRatio: {
       vg: 70,
       pg: 30,

--- a/src/Calculator.re
+++ b/src/Calculator.re
@@ -8,9 +8,11 @@ let make = () => {
       vg: 70,
       pg: 30,
     },
+    size: 100,
   };
 
   let (baseRatio, setBaseRatio) = React.useState(() => preset.baseRatio);
+  let (size, setSize) = React.useState(() => preset.size);
 
   <div>
     <div>
@@ -20,5 +22,6 @@ let make = () => {
     <div>
       <BaseRatioSelector preset=baseRatio handleSetBaseRatio=setBaseRatio />
     </div>
+    <div> <SizeSelector size handleSetSize=setSize /> </div>
   </div>;
 };

--- a/src/Constants.re
+++ b/src/Constants.re
@@ -9,3 +9,10 @@ type base =
 let convertBaseTypeToString = (value: base): string =>
   value === PG ? "PG" : "VG";
 let convertStringToBaseType = (str: string): base => str === "PG" ? PG : VG;
+
+type baseRatioPreference = {
+  vg: int,
+  pg: int,
+};
+
+type preference = {baseRatio: baseRatioPreference};

--- a/src/Constants.re
+++ b/src/Constants.re
@@ -10,9 +10,9 @@ let convertBaseTypeToString = (value: base): string =>
   value === PG ? "PG" : "VG";
 let convertStringToBaseType = (str: string): base => str === "PG" ? PG : VG;
 
-type baseRatioPreference = {
+type baseRatioPreset = {
   vg: int,
   pg: int,
 };
 
-type preference = {baseRatio: baseRatioPreference};
+type preset = {baseRatio: baseRatioPreset};

--- a/src/Constants.re
+++ b/src/Constants.re
@@ -18,4 +18,5 @@ type baseRatioPreset = {
 type preset = {
   name: string,
   baseRatio: baseRatioPreset,
+  size: int,
 };

--- a/src/Constants.re
+++ b/src/Constants.re
@@ -15,4 +15,7 @@ type baseRatioPreset = {
   pg: int,
 };
 
-type preset = {baseRatio: baseRatioPreset};
+type preset = {
+  name: string,
+  baseRatio: baseRatioPreset,
+};

--- a/src/SizeSelector.re
+++ b/src/SizeSelector.re
@@ -1,0 +1,17 @@
+[@react.component]
+let make = (~size: int, ~handleSetSize) => {
+  <div>
+    <span> {ReasonReact.string("Size:")} </span>
+    <input
+      label="size"
+      type_="number"
+      step=1.0
+      value={Js.Int.toString(size)}
+      onChange={event => {
+        let newSize: int =
+          int_of_float(Js.Math.trunc(ReactEvent.Form.target(event)##value));
+        handleSetSize(_ => newSize);
+      }}
+    />
+  </div>;
+};


### PR DESCRIPTION
Make a component to select the juice size

Size can't be a decimal number
Ratio can't be a decimal number

Not handle the best way, user can still enter a `.`

<img width="182" alt="Screen Shot 2019-09-08 at 3 43 29 PM" src="https://user-images.githubusercontent.com/818848/64495468-91b02400-d24f-11e9-9668-bbfe321f911a.png">
