### PR TITLE
Refactor use preset value in NicBaseSelector

### DIFF
--- a/src/Calculator.re
+++ b/src/Calculator.re
@@ -5,8 +5,8 @@ let make = () => {
   let preset: Constants.preset = {
     name: "default",
     nicBase: {
-      base: Constants.VG,
-      concentration: 24,
+      base: Constants.PG,
+      concentration: 99,
     },
     baseRatio: {
       vg: 70,

--- a/src/Calculator.re
+++ b/src/Calculator.re
@@ -5,8 +5,8 @@ let make = () => {
   let preset: Constants.preset = {
     name: "default",
     nicBase: {
-      base: Constants.PG,
-      concentration: 99,
+      base: Constants.VG,
+      concentration: 48,
     },
     baseRatio: {
       vg: 70,

--- a/src/Calculator.re
+++ b/src/Calculator.re
@@ -4,6 +4,10 @@ let make = () => {
 
   let preset: Constants.preset = {
     name: "default",
+    nicBase: {
+      base: Constants.VG,
+      concentration: 24,
+    },
     baseRatio: {
       vg: 70,
       pg: 30,
@@ -11,12 +15,30 @@ let make = () => {
     size: 100,
   };
 
+  let (nicBase, setNicBase) = React.useState(() => preset.nicBase);
   let (baseRatio, setBaseRatio) = React.useState(() => preset.baseRatio);
   let (size, setSize) = React.useState(() => preset.size);
 
+  let handleSetNicBase = newNicBase => {
+    setNicBase(_ => newNicBase);
+    let nicConcentration = Js.Int.toFloat(newNicBase.concentration) /. 10.0;
+    let nicWeight = nicConcentration *. Constants.nicWeightPerML;
+    let tmp = 100.0 -. nicConcentration;
+
+    let baseWeight =
+      switch (newNicBase.base) {
+      | PG => tmp *. Constants.pgWeightPerML
+      | VG => tmp *. Constants.vgWeightPerML
+      };
+
+    let result = (nicWeight +. baseWeight) /. 100.0;
+
+    setNicWeight(_ => result);
+  };
+
   <div>
     <div>
-      <NicBaseSelector handleSetNicWeight=setNicWeight />
+      <NicBaseSelector initPresetNicBase=nicBase handleSetNicBase />
       <p> {ReasonReact.string(Js.Float.toString(nicWeight))} </p>
     </div>
     <div>

--- a/src/Constants.re
+++ b/src/Constants.re
@@ -10,6 +10,11 @@ let convertBaseTypeToString = (value: base): string =>
   value === PG ? "PG" : "VG";
 let convertStringToBaseType = (str: string): base => str === "PG" ? PG : VG;
 
+type nicBasePreset = {
+  base,
+  concentration: int,
+};
+
 type baseRatioPreset = {
   vg: int,
   pg: int,
@@ -17,6 +22,7 @@ type baseRatioPreset = {
 
 type preset = {
   name: string,
+  nicBase: nicBasePreset,
   baseRatio: baseRatioPreset,
   size: int,
 };

--- a/src/NicBaseSelector.re
+++ b/src/NicBaseSelector.re
@@ -25,16 +25,33 @@ let make = (~initPresetNicBase: Constants.nicBasePreset, ~handleSetNicBase) => {
     | _ => findInitValueIndex(List.tl(list), index + 1)
     };
 
-  React.useEffect0(() => {
+  let setCustomDefaultValue = (initValue: Constants.nicBasePreset) => {
+    print_endline("No such item found!");
+    setCustomVisible(_ => true);
+    handleSetNicBase(initValue);
+  };
+
+  let setInitPresetNicBaseV1 = list =>
     switch (
       List.find(
         (item: Constants.nicBasePreset) => item == initPresetNicBase,
-        nicOptions,
+        list,
       )
     ) {
-    | exception Not_found => print_endline("Not found!")
+    | exception Not_found => setCustomDefaultValue(initPresetNicBase)
     | item => handleSetNicBase(item)
     };
+
+  let rec setInitPresetNicBaseV2 = list =>
+    switch (list) {
+    | [] => setCustomDefaultValue(initPresetNicBase)
+    | [head, ..._] when head == initPresetNicBase => handleSetNicBase(head)
+    | [_, ...tail] => setInitPresetNicBaseV2(tail)
+    };
+
+  React.useEffect0(() => {
+    //setInitPresetNicBaseV1(nicOptions);
+    setInitPresetNicBaseV2(nicOptions);
 
     None;
   });

--- a/src/NicBaseSelector.re
+++ b/src/NicBaseSelector.re
@@ -19,19 +19,22 @@ let make = (~initPresetNicBase: Constants.nicBasePreset, ~handleSetNicBase) => {
       <option value="Custom" key="Cutom"> {React.string("Custom")} </option>,
     ];
 
-  let rec findInitValueIndex = (list, index) =>
-    switch (List.hd(list) == initPresetNicBase) {
-    | true => index
-    | _ => findInitValueIndex(List.tl(list), index + 1)
-    };
-
   let setCustomDefaultValue = (initValue: Constants.nicBasePreset) => {
     print_endline("No such item found!");
     setCustomVisible(_ => true);
     handleSetNicBase(initValue);
+    setCustomNicValue(_ => initValue.concentration);
+    setCustomNicBase(_ => initValue.base);
   };
 
-  let setInitPresetNicBaseV1 = list =>
+  let rec findInitValueIndex = (list, index) =>
+    switch (list) {
+    | [] => List.length(nicOptions) // TODO: not working "Customs" not selected when use customs value as preset
+    | [head, ..._] when head == initPresetNicBase => index
+    | [_, ...tail] => findInitValueIndex(tail, index + 1)
+    };
+
+  let setInitPresetNicBase = list =>
     switch (
       List.find(
         (item: Constants.nicBasePreset) => item == initPresetNicBase,
@@ -42,16 +45,8 @@ let make = (~initPresetNicBase: Constants.nicBasePreset, ~handleSetNicBase) => {
     | item => handleSetNicBase(item)
     };
 
-  let rec setInitPresetNicBaseV2 = list =>
-    switch (list) {
-    | [] => setCustomDefaultValue(initPresetNicBase)
-    | [head, ..._] when head == initPresetNicBase => handleSetNicBase(head)
-    | [_, ...tail] => setInitPresetNicBaseV2(tail)
-    };
-
   React.useEffect0(() => {
-    //setInitPresetNicBaseV1(nicOptions);
-    setInitPresetNicBaseV2(nicOptions);
+    setInitPresetNicBase(nicOptions);
 
     None;
   });


### PR DESCRIPTION
## Reactor

- Use preset value for default value

## TODO

- When preset value not found in `nicOptions` should use the custom but throw error instead

<img width="566" alt="Screen Shot 2019-09-22 at 4 36 26 PM" src="https://user-images.githubusercontent.com/818848/65396079-28540900-dd57-11e9-9ae4-c97d00e87733.png">
